### PR TITLE
chore: downgrade swr

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -11,6 +11,6 @@
     "twind": "https://esm.sh/v98/twind@0.16.17",
     "twind/": "https://esm.sh/v98/twind@0.16.17/",
     "$std/": "https://deno.land/std@0.154.0/",
-    "swr": "https://esm.sh/v98/swr@2.0.0-beta.6?alias=react:preact/compat&external=preact/compat"
+    "swr": "https://esm.sh/v98/swr@2.1.4?alias=react:preact/compat&external=preact/compat"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -11,6 +11,6 @@
     "twind": "https://esm.sh/v98/twind@0.16.17",
     "twind/": "https://esm.sh/v98/twind@0.16.17/",
     "$std/": "https://deno.land/std@0.154.0/",
-    "swr": "https://esm.sh/v98/swr@2.1.4?alias=react:preact/compat&external=preact/compat"
+    "swr": "https://esm.sh/v98/swr@2.1.4?alias=react:preact/compat&deps=preact@10.10.6"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -11,6 +11,7 @@
     "twind": "https://esm.sh/v98/twind@0.16.17",
     "twind/": "https://esm.sh/v98/twind@0.16.17/",
     "$std/": "https://deno.land/std@0.154.0/",
-    "swr": "https://esm.sh/v98/swr@2.1.4?alias=react:preact/compat&deps=preact@10.10.6"
+    "swr": "https://esm.sh/v98/swr@2.1.4?alias=react:preact/compat&deps=preact@10.10.6",
+    "/stable/react@18.2.0/deno/react.mjs": "preact/compat"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -11,7 +11,6 @@
     "twind": "https://esm.sh/v98/twind@0.16.17",
     "twind/": "https://esm.sh/v98/twind@0.16.17/",
     "$std/": "https://deno.land/std@0.154.0/",
-    "swr": "https://esm.sh/v98/swr@2.1.4?alias=react:preact/compat&deps=preact@10.10.6",
-    "/stable/react@18.2.0/deno/react.mjs": "preact/compat"
+    "swr": "https://esm.sh/v98/swr@1.3.0?alias=react:preact/compat&external=preact/compat"
   }
 }

--- a/utils/data.ts
+++ b/utils/data.ts
@@ -98,7 +98,7 @@ async function cartFetcher(): Promise<CartData> {
 }
 
 export function useCart() {
-  return useSWR<CartData, Error>("cart", cartFetcher, { keepPreviousData: true });
+  return useSWR<CartData, Error>("cart", cartFetcher, {});
 }
 
 const ADD_TO_CART_QUERY =


### PR DESCRIPTION
This PR downgrades swr to 1.3.0, which seems restoring the cart feature.

closes #36

(Thanks @bdodroid for the idea!)

Note: This reopens #23